### PR TITLE
Modify the embed default size for the case of Figma Embed blocks to allow supporting wide view using the native aspect ratio classes provided by the editor

### DIFF
--- a/includes/FigmaBlock/Block.php
+++ b/includes/FigmaBlock/Block.php
@@ -24,6 +24,7 @@ class Block {
 
 		add_action( 'enqueue_block_editor_assets', [ $this, 'block_editor_assets' ] );
 		add_filter( 'rest_request_after_callbacks', [ $this, 'filter_rest_request_after_callbacks' ], 10, 3 );
+		add_filter( 'embed_defaults', [ $this, 'embed_defaults_for_figma_block' ], 10, 2 );
 	}
 
 	/**
@@ -104,5 +105,31 @@ class Block {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Modify the embed default size for the case of Figma Embed blocks to allow supporting wide view using the native
+	 * aspect ratio classes provided by the editor.
+	 *
+	 * @param int[]  $size The array of dimensions for the size
+	 * @param string $url  The URL that should be embedded.
+	 *
+	 * @return int[]
+	 */
+	public function embed_defaults_for_figma_block( $size, $url ) {
+		if ( empty( $url ) ) {
+			return $size;
+		}
+
+		$domain = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( 'www.figma.com' !== $domain ) {
+			return $size;
+		}
+
+		return [
+			'width'  => 600,
+			'height' => 452,
+		];
 	}
 }

--- a/src/assets/js/icon.js
+++ b/src/assets/js/icon.js
@@ -83,7 +83,7 @@ export const IconColor = () => (
 			width="95.0226"
 			height="142.534"
 			fill="black"
-			fill-opacity="0"
+			fillOpacity="0"
 			transform="translate(1.46603 2.19946) scale(3)"
 		/>
 		<Path


### PR DESCRIPTION
### Description of the Change
In this PR I'm modifying the embed default size for the case of Figma Embed blocks to allow supporting wide view using the native aspect ratio classes provided by the editor

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2

### How to test the Change
* Insert a Figma block into the post content
* Change the alignment option to `Wide` to make sure that block occupies the full width of the page

### Changelog Entry
> Fixed - Wide alignment of the block


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
