### PR TITLE
Remove vendor directory from export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 /node_modules export-ignore
 /src export-ignore
 /tests export-ignore
-/vendor export-ignore
 
 /.* export-ignore
 /CHANGELOG.md export-ignore


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Without the vendor directory, the plugin will fail:

https://github.com/10up/figma-block/blob/814a5f35aae26bf4d3c6cd5ae22875fa1ca10b54/figma-block.php#L75-L87

So we're removing `vendor` from `.gitattributes` export-ignore.
