### PR TITLE
Update Figma block name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Figma Block for WordPress
+# Embed Block for Figma for WordPress
 
 > Adds a Figma embed block to the WordPress Block Editor.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Embed Block for Figma for WordPress
+# Embed Block for Figma
 
-> Adds a Figma embed block to the WordPress Block Editor.
+> A Figma Block for the WordPress block editor (Gutenberg).
 
 [![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.5%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/block-catalog.svg)](https://github.com/10up/block-catalog/blob/develop/LICENSE.md)
 [![Dependency Review](https://github.com/10up/figma-block/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/figma-block/actions/workflows/dependency-review.yml) [![PHP Compatibility](https://github.com/10up/figma-block/actions/workflows/php-compat.yml/badge.svg)](https://github.com/10up/figma-block/actions/workflows/php-compat.yml) [![PHP Linting](https://github.com/10up/figma-block/actions/workflows/phpcs.yml/badge.svg)](https://github.com/10up/figma-block/actions/workflows/phpcs.yml) [![JS Linting](https://github.com/10up/figma-block/actions/workflows/eslint.yml/badge.svg)](https://github.com/10up/figma-block/actions/workflows/eslint.yml)

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "10up/figma-block",
+  "name": "10up/embed-block-figma",
   "description": "Adds a Figma embed block to the WordPress Block Editor.",
   "type": "wordpress-plugin",
-  "homepage": "https://github.com/10up/figma-block",
+  "homepage": "https://github.com/10up/embed-block-figma",
   "license": "GPL-2.0-or-later",
   "authors": [
     {

--- a/embed-block-figma.php
+++ b/embed-block-figma.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name:       Figma Block
- * Plugin URI:        https://github.com/10up/figma-block
+ * Plugin Name:       Embed Block for Figma
+ * Plugin URI:        https://github.com/10up/embed-block-figma
  * Description:       Adds a Figma embed block to the WordPress Block Editor.
  * Version:           0.2.0
  * Requires at least: 6.4
@@ -10,7 +10,7 @@
  * Author URI:        https://10up.com
  * License:           GPL-2.0-or-later
  * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
- * Text Domain:       figma-block
+ * Text Domain:       embed-block-figma
  * Domain Path:       /languages
  *
  * @package FigmaBlock
@@ -58,7 +58,7 @@ if ( ! site_meets_php_requirements() ) {
 					echo wp_kses_post(
 						sprintf(
 							/* translators: %s: Minimum required PHP version */
-							__( 'The Figma Block plugin requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'figma-block' ),
+							__( 'The Embed Block for Figma plugin requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'embed-block-figma' ),
 							esc_html( minimum_php_requirement() )
 						)
 					);
@@ -78,7 +78,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	add_action(
 		'admin_notices',
 		function () {
-			$message = __( 'Error: Please run $ composer install in the Figma Block plugin directory.', 'figma-block' );
+			$message = __( 'Error: Please run $ composer install in the Embed Block for Figma plugin directory.', 'embed-block-figma' );
 			printf( '<div class="%1$s"><p>%2$s</p></div>', 'notice notice-error', esc_html( $message ) );
 			error_log( esc_html( $message ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}

--- a/includes/FigmaBlock/Plugin.php
+++ b/includes/FigmaBlock/Plugin.php
@@ -50,6 +50,6 @@ class Plugin {
 	 * Load translations.
 	 */
 	public function i18n() {
-		load_plugin_textdomain( 'figma-block', false, FIGMA_BLOCK_PATH . '/languages' );
+		load_plugin_textdomain( 'embed-block-figma', false, FIGMA_BLOCK_PATH . '/languages' );
 	}
 }

--- a/languages/figma-block.pot
+++ b/languages/figma-block.pot
@@ -2,8 +2,8 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Figma Block 0.1.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/figma-block\n"
+"Project-Id-Version: Embed Block for Figma 0.1.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/embed-block-figma\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,10 +12,10 @@ msgstr ""
 "POT-Creation-Date: 2024-03-12T17:56:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
-"X-Domain: figma-block\n"
+"X-Domain: embed-block-figma\n"
 
 #. Plugin Name of the plugin
-msgid "Figma Block"
+msgid "Embed Block for Figma"
 msgstr ""
 
 #. Plugin URI of the plugin
@@ -32,6 +32,6 @@ msgid "10up"
 msgstr ""
 
 #. translators: %s: Minimum required PHP version
-#: figma-block.php:61
-msgid "The Figma Block plugin requires PHP version %s or later. Please upgrade PHP or disable the plugin."
+#: embed-block-figma.php:61
+msgid "The Embed Block for Figma plugin requires PHP version %s or later. Please upgrade PHP or disable the plugin."
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "figma-block",
+  "name": "embed-block-figma",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "figma-block",
+      "name": "embed-block-figma",
       "version": "0.2.0",
       "devDependencies": {
         "10up-toolkit": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "figma-block",
+  "name": "embed-block-figma",
   "version": "0.2.0",
   "description": "Adds a Figma embed block to the WordPress Block Editor.",
-  "homepage": "https://github.com/10up/figma-block",
+  "homepage": "https://github.com/10up/embed-block-figma",
   "license": "GPL-2.0-or-later",
   "author": {
     "name": "10up",

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Figma Block ===
+=== Embed Block for Figma ===
 Contributors:      10up, dkotter, jeffpaul
 Tags:              gutenberg, figma, embed, blocks, custom blocks
 Tested up to:      6.6

--- a/src/assets/js/figma-embed.js
+++ b/src/assets/js/figma-embed.js
@@ -12,7 +12,7 @@ import { IconColor } from './icon';
 registerBlockVariation('core/embed', {
 	name: 'figma',
 	title: 'Figma',
-	description: __('Embed Figma designs.'),
+	description: __('Embed Figma designs.', 'embed-block-figma'),
 	icon: { src: IconColor, foreground: 'transparent' },
 	patterns: [/https:\/\/[\w.-]+\.?figma.com\/([\w-]+)\/([0-9a-zA-Z]{22,128})(?:\/.*)?$/i],
 	attributes: {


### PR DESCRIPTION
### Description of the Change

- Renames the plugin file and name, updates text-domain.

Closes https://github.com/10up/figma-block/issues/26

### How to test the Change

- Activate the plugin.
- Confirm the plugin name is updated.
- Confirm the plugin file is updated.
- Confirm the block still loads and works as expected.

### Changelog Entry

Changed - Plugin Name 

### Credits
@jeffpaul @thrijith 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
