### PR TITLE
Update naming from `figma-block` to `embed-block-figma`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ All notable changes to this project will be documented in this file, per [the Ke
 **Initial public plugin release. 🎉**
 
 ### Changed
-- Bump WordPress "tested up to" version 6.6 (props [@psorensen](https://github.com/psorensen), [@jeffpaul](https://github.com/jeffpaul) via [#21](https://github.com/10up/figma-block/pull/21)).
-- Updated documentation (props [@jeffpaul](https://github.com/jeffpaul) via [#17](https://github.com/10up/figma-block/pull/17)).
+- Bump WordPress "tested up to" version 6.6 (props [@psorensen](https://github.com/psorensen), [@jeffpaul](https://github.com/jeffpaul) via [#21](https://github.com/10up/embed-block-figma/pull/21)).
+- Updated documentation (props [@jeffpaul](https://github.com/jeffpaul) via [#17](https://github.com/10up/embed-block-figma/pull/17)).
 
 ### Security
-- Bump `braces` from 3.0.2 to 3.0.3 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/figma-block/pull/15)).
-- Bump `ws` from 7.5.9 to 7.5.10 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/figma-block/pull/15)).
+- Bump `braces` from 3.0.2 to 3.0.3 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/embed-block-figma/pull/15)).
+- Bump `ws` from 7.5.9 to 7.5.10 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/embed-block-figma/pull/15)).
 
 ## [0.1.0] - 2024-06-25
 - Initial private plugin release.
 
-[Unreleased]: https://github.com/10up/figma-block/compare/trunk...develop
-[0.2.0]: https://github.com/10up/figma-block/compare/0.1.0...0.2.0
-[0.1.0]: https://github.com/10up/figma-block/tree/v0.1.0
+[Unreleased]: https://github.com/10up/embed-block-figma/compare/trunk...develop
+[0.2.0]: https://github.com/10up/embed-block-figma/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/10up/embed-block-figma/tree/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Contributing isn't just writing code - it's anything that improves the project. 
 
 ### Reporting bugs
 
-If you're running into an issue with the plugin, please take a look through [existing issues](https://github.com/10up/figma-block/issues) and [open a new one](https://github.com/10up/figma-block/issues/new) if needed. If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
+If you're running into an issue with the plugin, please take a look through [existing issues](https://github.com/10up/embed-block-figma/issues) and [open a new one](https://github.com/10up/embed-block-figma/issues/new) if needed. If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
 
 ### Suggesting enhancements
 
-New features and enhancements are also managed via [issues](https://github.com/10up/figma-block/issues).
+New features and enhancements are also managed via [issues](https://github.com/10up/embed-block-figma/issues).
 
 ### Pull requests
 
@@ -29,17 +29,17 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-1. Version bump: Bump the version number in `figma-block.php`, `package-lock.json`, `package.json`, and `readme.txt` if it does not already reflect the version being released. In `figma-block.php` update both the plugin "Version:" property and the plugin `FIGMA_BLOCK_VERSION` constant.
+1. Version bump: Bump the version number in `embed-block-figma.php`, `package-lock.json`, `package.json`, and `readme.txt` if it does not already reflect the version being released. In `embed-block-figma.php` update both the plugin "Version:" property and the plugin `FIGMA_BLOCK_VERSION` constant.
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`.
 1. Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
 1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
 1. Readme updates: Make any other readme changes as necessary. `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
 1. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `trunk`, ensuring you pull the most recent changes into `develop` first (`git checkout develop && git pull origin develop && git checkout trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
 1. Push: Push your trunk branch to GitHub (e.g. `git push origin trunk`).
-1. [Compare](https://github.com/10up/figma-block/compare/trunk...develop) `trunk` to `develop` to ensure no additional changes were missed.
-1. Test the pre-release ZIP locally by [downloading](https://github.com/10up/figma-block/actions/workflows/build-release-zip.yml) it from the Build release zip action artifact and installing it locally. Ensure this zip has all the files we expect, that it installs and activates correctly and that all basic functionality is working.
-1. Release: Create a [new release](https://github.com/10up/figma-block/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/figma-block/milestone/#?closed=1).
-1. SVN: Wait for the [GitHub Action](https://github.com/10up/figma-block/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
-1. Check WordPress.org: Ensure that the changes are live on [WordPress.org](https://wordpress.org/plugins/figma-block/). This may take a few minutes.
-1. Close milestone: Edit the [milestone](https://github.com/10up/figma-block/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
+1. [Compare](https://github.com/10up/embed-block-figma/compare/trunk...develop) `trunk` to `develop` to ensure no additional changes were missed.
+1. Test the pre-release ZIP locally by [downloading](https://github.com/10up/embed-block-figma/actions/workflows/build-release-zip.yml) it from the Build release zip action artifact and installing it locally. Ensure this zip has all the files we expect, that it installs and activates correctly and that all basic functionality is working.
+1. Release: Create a [new release](https://github.com/10up/embed-block-figma/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/embed-block-figma/milestone/#?closed=1).
+1. SVN: Wait for the [GitHub Action](https://github.com/10up/embed-block-figma/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+1. Check WordPress.org: Ensure that the changes are live on [WordPress.org](https://wordpress.org/plugins/embed-block-figma/). This may take a few minutes.
+1. Close milestone: Edit the [milestone](https://github.com/10up/embed-block-figma/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
 1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.

--- a/readme.txt
+++ b/readme.txt
@@ -33,10 +33,10 @@ Assuming it's a valid URL, the block will automatically fetch the Figma file and
 
 **Initial public plugin release. 🎉**
 
-* **Changed:** Bump WordPress "tested up to" version 6.6 (props [@psorensen](https://github.com/psorensen), [@jeffpaul](https://github.com/jeffpaul) via [#21](https://github.com/10up/figma-block/pull/21)).
-* **Changed:** Updated documentation (props [@jeffpaul](https://github.com/jeffpaul) via [#17](https://github.com/10up/figma-block/pull/17)).
-* **Security:** Bump `braces` from 3.0.2 to 3.0.3 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/figma-block/pull/15)).
-* **Security:** Bump `ws` from 7.5.9 to 7.5.10 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/figma-block/pull/15)).
+* **Changed:** Bump WordPress "tested up to" version 6.6 (props [@psorensen](https://github.com/psorensen), [@jeffpaul](https://github.com/jeffpaul) via [#21](https://github.com/10up/embed-block-figma/pull/21)).
+* **Changed:** Updated documentation (props [@jeffpaul](https://github.com/jeffpaul) via [#17](https://github.com/10up/embed-block-figma/pull/17)).
+* **Security:** Bump `braces` from 3.0.2 to 3.0.3 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/embed-block-figma/pull/15)).
+* **Security:** Bump `ws` from 7.5.9 to 7.5.10 (props [@dependabot](https://github.com/apps/dependabot), [@psorensen](https://github.com/psorensen) via [#15](https://github.com/10up/embed-block-figma/pull/15)).
 
 = 0.1.0 - 2024-06-25 =
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR completes the renaming of references across the codebase from `figma-block` to `embed-block-figma`.

### How to test the Change
Preview using the GH markdown previewer.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Plugin rename from Figma Block to Embed Block for Figma.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
