### PR TITLE
add WP and PHP minimum badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 ![Figma Block](https://github.com/10up/embed-block-figma/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.5%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/embed-block-figma.svg)](https://github.com/10up/embed-block-figma/blob/develop/LICENSE.md) [![WordPress Playground Demo](https://img.shields.io/github/v/release/10up/embed-block-figma?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/embed-block-figma/trunk/.wordpress-org/blueprints/blueprint.json)
-[![Dependency Review](https://github.com/10up/embed-block-figma/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/dependency-review.yml) [![PHP Compatibility](https://github.com/10up/embed-block-figma/actions/workflows/php-compat.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/php-compat.yml) [![PHP Linting](https://github.com/10up/embed-block-figma/actions/workflows/phpcs.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/phpcs.yml) [![JS Linting](https://github.com/10up/embed-block-figma/actions/workflows/eslint.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/eslint.yml)
+[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) ![Required PHP Version](https://img.shields.io/wordpress/plugin/required-php/retro-winamp-block?label=Requires%20PHP) ![Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/retro-winamp-block?label=Requires%20WordPress) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.5%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/embed-block-figma.svg)](https://github.com/10up/embed-block-figma/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/embed-block-figma/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/dependency-review.yml) [![PHP Compatibility](https://github.com/10up/embed-block-figma/actions/workflows/php-compat.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/php-compat.yml) [![PHP Linting](https://github.com/10up/embed-block-figma/actions/workflows/phpcs.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/phpcs.yml) [![JS Linting](https://github.com/10up/embed-block-figma/actions/workflows/eslint.yml/badge.svg)](https://github.com/10up/embed-block-figma/actions/workflows/eslint.yml) [![WordPress Playground Demo](https://img.shields.io/github/v/release/10up/embed-block-figma?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/embed-block-figma/trunk/.wordpress-org/blueprints/blueprint.json)
 
 > A Figma Block for the WordPress block editor (Gutenberg).
-
-![Screenshot of the rendered Figma Embed block in the editor / admin](.wordpress-org/screenshot-2.png)
 
 ## Features
 
@@ -15,7 +12,7 @@
 * Paste a Figma URL on a new line in the Block Editor to automatically convert it to a Figma Embed block.
 * Block settings allow for altering margins of rendered Figma file embed
 
-![Screenshot of the Figma Embed block settings prior to rendering in the editor / admin](.wordpress-org/screenshot-3.png)
+![Screenshot of the rendered Figma Embed block in the editor / admin](.wordpress-org/screenshot-2.png)
 
 ## Requirements
 
@@ -26,6 +23,8 @@
 
 * You can install the plugin manually by [downloading a zip file](https://github.com/10up/embed-block-figma/releases/latest) from GitHub.
 * You then need to upload the zip file to your WordPress site by going to *WP-Admin > Plugins > Add New > Upload Plugin* and selecting the zip file from your computer.
+
+![Screenshot of the Figma Embed block settings prior to rendering in the editor / admin](.wordpress-org/screenshot-3.png)
 
 ## Getting Started
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds badges to note the WordPress and PHP minimums for this plugin.  I did NOT remove the "Requirements" section of the `README.md` file, but I wonder if that might be worthwhile so that we don't need to worry about remembering to update those references in the future (as the badges auto-update based on what's shown on the WP.org repo)?

### How to test the Change
Use GitHub markdown previewer to see updated badges.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
