### PR TITLE
Bump Tested up to

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org) 6.4+
+* [WordPress](http://wordpress.org) 6.5+
 
 ## Installation
 

--- a/embed-block-figma.php
+++ b/embed-block-figma.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/embed-block-figma
  * Description:       Adds a Figma embed block to the WordPress Block Editor.
  * Version:           0.3.1
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/phpcs-compat.xml
+++ b/phpcs-compat.xml
@@ -14,6 +14,6 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.5"/>
 	<config name="testVersion" value="7.4-"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
 	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.5"/>
 	<config name="testVersion" value="7.4-"/>
 
 	<!-- Exclude the PHPCompatibilityWP ruleset -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Embed Block for Figma ===
 Contributors:      10up, dkotter, jeffpaul
 Tags:              gutenberg, figma, embed, blocks, custom blocks
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        0.3.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
[### Description of the Change

- I've tested the plugin on `6.7-RC1`, inserted the block and set this url https://www.figma.com/proto/nrPSsILSYjesyc5UHjYYa4/Embed-Kit-2.0-examples?content-scaling=fixed&kind=proto&node-id=5-3&scaling=scale-down, confirmed it displays correctly.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/embed-block-figma/issues/41

### How to test the Change
-  Update to 6.7 release candidate, confirm block works as expected

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.7.
> Changed - Requires at least WordPress version to 6.5.

### Credits
Props @username, @username2, ...

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
](https://github.com/10up/embed-block-figma/issues/41)