### PR TITLE
Fix the WordPress Plugin Preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -11,7 +11,7 @@
   "steps": [
     {
       "step": "login",
-      "username": "admin",
+      "username": "admin"
     },
     {
       "step": "installPlugin",

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -5,9 +5,6 @@
     "php": "7.4",
     "wp": "latest"
   },
-  "phpExtensionBundles": [
-    "kitchen-sink"
-  ],
   "features": {
     "networking": true
   },
@@ -15,11 +12,10 @@
     {
       "step": "login",
       "username": "admin",
-      "password": "password"
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "wordpress.org\/plugins",
         "slug": "embed-block-figma"
       },

--- a/.wordpress-org/blueprints/demo-data.xml
+++ b/.wordpress-org/blueprints/demo-data.xml
@@ -37,7 +37,7 @@
 
 		<wp:author><wp:author_id>1</wp:author_id><wp:author_login><![CDATA[admin]]></wp:author_login><wp:author_email><![CDATA[admin@localhost.com]]></wp:author_email><wp:author_display_name><![CDATA[admin]]></wp:author_display_name><wp:author_first_name><![CDATA[]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
 
-				
+
 	<generator>https://wordpress.org/?v=6.6.1</generator>
 
 		<item>
@@ -47,9 +47,9 @@
 		<dc:creator><![CDATA[admin]]></dc:creator>
 		<guid isPermaLink="false">https://playground.wordpress.net/scope:0.1624312760462985/?page_id=7</guid>
 		<description></description>
-		<content:encoded><![CDATA[<!-- wp:embed {"url":"https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-Filesss","type":"rich","providerNameSlug":"figma","responsive":true,"className":"wp-embed-aspect-4-3 wp-has-aspect-ratio"} -->
+		<content:encoded><![CDATA[<!-- wp:embed {"url":"https://www.figma.com/proto/nrPSsILSYjesyc5UHjYYa4/Embed-Kit-2.0-examples?node-id=5-3&starting-point-node-id=5%3A3","type":"rich","providerNameSlug":"figma","responsive":true,"className":"wp-embed-aspect-4-3 wp-has-aspect-ratio"} -->
 <figure class="wp-block-embed is-type-rich is-provider-figma wp-block-embed-figma wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-Filesss
+https://www.figma.com/proto/nrPSsILSYjesyc5UHjYYa4/Embed-Kit-2.0-examples?node-id=5-3&starting-point-node-id=5%3A3
 </div></figure>
 <!-- /wp:embed -->]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -74,4 +74,3 @@ https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-Filesss
 							</item>
 				</channel>
 </rss>
-	


### PR DESCRIPTION
### Description of the Change

As mentioned here: https://github.com/10up/embed-block-figma/issues/46#issuecomment-2828524403, the Figma file we reference in our plugin preview no longer seems to work.

This PR changes that to a new file and also fixes some deprecation warnings.

### How to test the Change

Go to this Plugin Preview link and ensure it works as expected: https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin/post.php?post=7&action=edit%22,%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22},{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22embed-block-figma%22},%22options%22:{%22activate%22:true}},{%22step%22:%22importWxr%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/10up/embed-block-figma/fix/plugin-preview/.wordpress-org/blueprints/demo-data.xml%22}}]}

### Changelog Entry

> Developer - Update the plugin preview blueprint to fix errors

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
