### PR TITLE
Set permissions to allow release asset attachment during release deploys

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   tag:
     name: New release

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  packages: write
+  packages: read
 
 jobs:
   tag:


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request makes a small update to the GitHub Actions workflow configuration for WordPress plugin deployment. The main change is the addition of explicit permissions for the workflow.

* Added `permissions` for `contents: write` and `packages: write` in `.github/workflows/wordpress-plugin-deploy.yml` to ensure the workflow can modify repository contents and packages.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Ensure release deploy action permissions allow for attaching release assets.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
