### PR TITLE
Fix/workflow perms

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: Build release zip
 
 on:
@@ -8,6 +6,9 @@ on:
   push:
     branches:
       - trunk
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build release zip
 
 on:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,11 +1,12 @@
-permissions:
-  contents: read
 name: E2E test
 
 on:
   pull_request:
     branches:
       - develop
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: E2E test
 
 on:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: JS Linting
 
 on:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: JS Linting
 
 on:
@@ -14,6 +12,9 @@ on:
       - develop
     paths:
       - '**.js'
+
+permissions:
+  contents: read
 
 jobs:
   eslint:

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - "**.php"
 
+permissions:
+  contents: read
+
 jobs:
   php-compatibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - "**.php"
 
+permissions:
+  contents: read
+
 jobs:
   phpcs:
     runs-on: ubuntu-latest

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -1,11 +1,12 @@
-permissions:
-  contents: read
 name: Plugin asset/readme update
 
 on:
   push:
     branches:
     - trunk
+
+permissions:
+  contents: read
 
 jobs:
   trunk:

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Plugin asset/readme update
 
 on:


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates several GitHub Actions workflow files to explicitly set the required permissions for workflow runs. The main change is the addition of a `permissions` block with `contents: read` to each workflow, which improves security by restricting the permissions granted to workflow jobs.

**Workflow permissions hardening:**

* Added `permissions: contents: read` to `.github/workflows/build-release-zip.yml` to limit access to repository contents.
* Added `permissions: contents: read` to `.github/workflows/cypress.yml` for enhanced security.
* Added `permissions: contents: read` to `.github/workflows/eslint.yml` to restrict permissions.
* Added `permissions: contents: read` to `.github/workflows/php-compat.yml` for improved workflow security.
* Added `permissions: contents: read` to `.github/workflows/phpcs.yml` to further limit job permissions.
* Added `permissions: contents: read` to `.github/workflows/wordpress-plugin-asset-update.yml` to ensure jobs only have read access to repository contents.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Updated GitHub Action workflows to include proper permissions scoping.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
